### PR TITLE
Fix path to prompt.txt

### DIFF
--- a/gut.py
+++ b/gut.py
@@ -24,7 +24,9 @@ def request_api_key():
     return api_key
 
 def send_to_groq(git_output):
-    with open('prompt.txt', 'r') as f:
+    # Construct the path to 'prompt.txt' using os.path.join and os.path.dirname
+    prompt_path = os.path.join(os.path.dirname(__file__), 'prompt.txt')
+    with open(prompt_path, 'r') as f:
         prompt = f.read().strip()
     
     url = "https://api.groq.com/openai/v1/chat/completions"


### PR DESCRIPTION
Related to #1

Update the path to `prompt.txt` in `send_to_groq` function to avoid `FileNotFoundError`.

* Construct the path to `prompt.txt` using `os.path.join(os.path.dirname(__file__), 'prompt.txt')`.
* Open `prompt.txt` using the constructed path in the `send_to_groq` function.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cpfiffer/gut/issues/1?shareId=79acf137-1856-4788-9278-3344fe9a4ea3).